### PR TITLE
Add warning for BOM (Byte Order Mark) in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,9 @@ cd <path to your folder>
 ```
 git checkout -b your_branch_name
 ```
+
+Be wary of encoding issues, use UTF-8 without BOM (Byte Order Marks), many editors can silently include BOM and cause issues.
+
 - Do your changes and commit:
 ```
 git commit -am "commit message"


### PR DESCRIPTION
I had a lot of issues that I struggled with regarding encoding, took me a while to discover it seems to be editors inserting a BOM in UTF-8 files.
