### PR TITLE
Small fixes

### DIFF
--- a/_exercises/en/05-advanced-topics-1/03-effect_slicer.md
+++ b/_exercises/en/05-advanced-topics-1/03-effect_slicer.md
@@ -5,7 +5,7 @@ lang: en
 layout: exercise
 ---
 
-In addition to the sample slicing presented in the previous topic, you can also use the audio effect `:slicer` to add some "rhythmic and chops" to your music. It basically alters the volume of the sound over time (and this effect is often called amplitude modulation). Now let's start our experiment with this effect by creating a new `live_loop` in an empty buffer and use the sample `:loop_breakbeat` as our building block: 
+In addition to the sample slicing presented in the previous topic, you can also use the audio effect `:slicer` to add some "rhythmic and chops" to your music. It basically alters the volume of the sound over time (and this effect is often called amplitude modulation). Now let's start our experiment with this effect by creating a new `live_loop` in an empty buffer and use the sample `:loop_breakbeat` as our building block:
 
 {% highlight ruby %}
 use_bpm 120
@@ -35,13 +35,13 @@ end
 
 {% include player.html filepath="/assets/audio/breakbeat_slicer.mp3" %}
 
-Now the newly added slicer effect sounds too harsh and we'll need to tune it a little bit. The main options of the slicer effect are `phase`, `wave` and `mix`. You can use them to control the amplitude modulation. The option `phase` is the frequency how fast or slow the amplitude modulation occurs. The default value for `phase`is `0.25` which means that the effect occurs every 1/16th note. Because of this the previous example sounded rather hectic. 
+Now the newly added slicer effect sounds too harsh and we'll need to tune it a little bit. The main options of the slicer effect are `phase`, `wave` and `mix`. You can use them to control the amplitude modulation. The option `phase` is the frequency how fast or slow the amplitude modulation occurs. The default value for `phase`is `0.25` which means that the effect occurs every 1/16th note. Because of this the previous example sounded rather hectic.
 
-Slicer effect can modulate the amplitude by using four different waveforms: `0`(saw), `1` (pulse), `2` (triangle) and `3`(sinewave). By default, `wave` is set to `1` which means that is uses pulse (also known as square) wave to modulate the amplitude. The pictures below illustrate what the waveforms look like and how they increase or decrease the amplitude (area marked with red color) over time. 
+Slicer effect can modulate the amplitude by using four different waveforms: `0`(saw), `1` (pulse), `2` (triangle) and `3`(sinewave). By default, `wave` is set to `1` which means that is uses pulse (also known as square) wave to modulate the amplitude. The pictures below illustrate what the waveforms look like and how they increase or decrease the amplitude (area marked with red color) over time.
 
 <img src="{{ "/assets/img/slicer_waveforms.png" | prepend: site.baseurl }}" width="100%">
 
-Now let's try to change the waveform to the saw (`wave: 0`). This should make the effect a little bit smoother and less abrupt. 
+Now let's try to change the waveform to the saw (`wave: 0`). This should make the effect a little bit smoother and less abrupt.
 
 {% highlight ruby %}
 use_bpm 120
@@ -60,11 +60,11 @@ Let's double the duration of the phase (`phase: 0.5`) and switch the waveform to
 
 {% include videoplayer.html filepath="/assets/video/fx_slicer_wave_1" %}
 
-Now what happens if we use the following options (`phase: 0.5, wave: 1`) with the effect:
+Now what happens if we use the following options (`phase: 0.5, wave: 2`) with the effect:
 
 {% include videoplayer.html filepath="/assets/video/fx_slicer_wave_2" %}
 
-This way it's quite easy to add some rhythm, variance and dynamics to the drum loops. Remember that you can also use this with the synthesizers in Sonic Pi! 
+This way it's quite easy to add some rhythm, variance and dynamics to the drum loops. Remember that you can also use this with the synthesizers in Sonic Pi!
 
 Here is the last slicer effect example that uses longer phase times with the slicer effect:
 

--- a/_exercises/fr/04-generate-sounds/02-tick.md
+++ b/_exercises/fr/04-generate-sounds/02-tick.md
@@ -85,4 +85,4 @@ live_loop :melodie do
 end
 {% endhighlight %}
 
-Commence à itérer, vas-y&nbsp!
+Commence à itérer, vas-y&nbsp;!

--- a/_exercises/fr/05-advanced-topics-1/04-external-samples.md
+++ b/_exercises/fr/05-advanced-topics-1/04-external-samples.md
@@ -14,7 +14,7 @@ Après avoir téléchargé le pack et extrait les fichiers dans un répertoire, 
 * Windows: "C:/Users/sam/Desktop/Samples"
 * Raspberry Pi, Linux et Mac: "/Users/sam/Desktop/Samples"
 
-Rappelle-toi juste de remplacer 'sam' par ton propre nom d'utilisateur. Le pack d'échantillons contient les fichiers suivants&nbsp;: de `hit_1.wav` à `hit_7.wav` (coups de percussion) et de `loop_1.wav` à `loop_7.wav` (boucle rythmiques qu'il est recommandé de jouer avec l'option `beat_stretch`).
+Rappelle-toi juste de remplacer 'sam' par ton propre nom d'utilisateur. Le pack d'échantillons contient les fichiers suivants&nbsp;: de `hit_1.wav` à `hit_7.wav` (coups de percussion) et de `loop_1.wav` à `loop_7.wav` (boucles rythmiques qu'il est recommandé de jouer avec l'option `beat_stretch`).
 
 Tu peux les jouer directement avec la commande `sample` en spécifiant le bon chemin&nbsp;:
 
@@ -34,7 +34,7 @@ live_loop :solenoid1 do
 end
 {% endhighlight %}
 
-Maintenant tu peux utiliser des samples externes et des samples internes à Soni Pi dans tes productions. Essaie de jouer l'exemple ci-dessous qui utilise quatre `live_loop` différentes pour jouer des samples externes et aussi un de Sonic Pi. Remarque aussi que dans la live_loop `:solenoid2` nous utilisons une variable `nomsample` pour choisir au hasard un des samples entre `hit_1.wav` et `hit_7.wav`.
+Maintenant tu peux utiliser des samples externes et des samples internes à Sonic Pi dans tes productions. Essaie de jouer l'exemple ci-dessous qui utilise quatre `live_loop` différentes pour jouer des samples externes et aussi un de Sonic Pi. Remarque aussi que dans la live_loop `:solenoid2` nous utilisons une variable `nomsample` pour choisir au hasard un des samples entre `hit_1.wav` et `hit_7.wav`.
 
 {% highlight ruby %}
 solenoids = "/Users/sam/Desktop/Samples/"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,13 +12,13 @@
 
       <div class="lang">
         {% if page.lang == "fi" %}
-          <a href="{{ '/index.html' | prepend: site.baseurl }}">in english</a> 
+          <a href="{{ '/index.html' | prepend: site.baseurl }}">in english</a>
           <a href="{{ '/index_se.html' | prepend: site.baseurl }}">svenska</a>
           <a href="{{ '/index_no.html' | prepend: site.baseurl }}">norsk</a>
           <a href="{{ '/index_kr.html' | prepend: site.baseurl }}">korean</a>
           <a href="{{ '/index_fr.html' | prepend: site.baseurl }}">français</a>
         {% elsif page.lang == "en" %}
-          <a href="{{ '/index_fi.html' | prepend: site.baseurl }}">suomeksi</a> 
+          <a href="{{ '/index_fi.html' | prepend: site.baseurl }}">suomeksi</a>
           <a href="{{ '/index_se.html' | prepend: site.baseurl }}">svenska</a>
           <a href="{{ '/index_no.html' | prepend: site.baseurl }}">norsk</a>
           <a href="{{ '/index_kr.html' | prepend: site.baseurl }}">korean</a>
@@ -28,18 +28,18 @@
           <a href="{{ '/index_no.html' | prepend: site.baseurl }}">norsk</a>
           <a href="{{ '/index_fi.html' | prepend: site.baseurl }}">suomeksi</a>
           <a href="{{ '/index_se.html' | prepend: site.baseurl }}">svenska</a>
-          <a href="{{ '/index_no.html' | prepend: site.baseurl }}">norsk</a>
+          <a href="{{ '/index_fr.html' | prepend: site.baseurl }}">français</a>
         {% elsif page.lang == "se" %}
           <a href="{{ '/index_fi.html' | prepend: site.baseurl }}">suomeksi</a>
           <a href="{{ '/index_no.html' | prepend: site.baseurl }}">norsk</a>
           <a href="{{ '/index.html' | prepend: site.baseurl }}">in english</a>
           <a href="{{ '/index_fr.html' | prepend: site.baseurl }}">français</a>
-          <a href="{{ '/index_kr.html' | prepend: site.baseurl }}">korean</a>          
+          <a href="{{ '/index_kr.html' | prepend: site.baseurl }}">korean</a>
         {% elsif page.lang == "fr" %}
           <a href="{{ '/index.html' | prepend: site.baseurl }}">in english</a>
           <a href="{{ '/index_fi.html' | prepend: site.baseurl }}">suomeksi</a>
           <a href="{{ '/index_no.html' | prepend: site.baseurl }}">norsk</a>
-          <a href="{{ '/index_se.html' | prepend: site.baseurl }}">svenska</a>          
+          <a href="{{ '/index_se.html' | prepend: site.baseurl }}">svenska</a>
           <a href="{{ '/index_kr.html' | prepend: site.baseurl }}">korean</a>
         {% else %}
           <a href="{{ '/index.html' | prepend: site.baseurl }}">in english</a> 


### PR DESCRIPTION
When in Korean, the French link is missing.
Semicolon missing and Sonic Pi misspelled in French version.
Bad waveform number  for the third example in the English version of 03-effect-slicer.